### PR TITLE
Custom marking of encrypted messages

### DIFF
--- a/fish.py
+++ b/fish.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 #
+# Copyright (C) 2012 Markus Näsman <markus@botten.org>
 # Copyright (C) 2011 David Flatz <david@upcs.at>
 # Copyright (C) 2009 Bjorn Edstrom <be@bjrn.se>
 #
@@ -144,6 +145,16 @@ def fish_config_init():
             fish_config_file, fish_config_section["look"], "marker",
             "string", "marker for important FiSH messages", "", 0, 0,
             "O<", "O<", 0, "", "", "", "", "", "")
+
+    fish_config_option["mark_position"] = weechat.config_new_option(
+            fish_config_file, fish_config_section["look"], "mark_position",
+            "string", "put marker for encrypted INCOMING messages at start or end", "off|begin|end",
+            0,0, "off", "off", 0, "", "", "", "", "", "")
+
+    fish_config_option["mark_encrypted"] = weechat.config_new_option(
+            fish_config_file, fish_config_section["look"], "mark_encrypted",
+            "string", "marker for encrypted INCOMING messages", "", 0, 0,
+            "*", "*", 0, "", "", "", "", "", "")
 
     # color
     fish_config_section["color"] = weechat.config_new_section(fish_config_file,
@@ -584,12 +595,11 @@ def fish_modifier_in_notice_cb(data, modifier, server_name, string):
 
         fish_announce_encrypted(buffer, target)
 
-        return "%s%s" % (match.group(1), clean)
+        return "%s%s" % (match.group(1), fish_msg_w_marker(clean))
 
     fish_announce_unencrypted(buffer, target)
 
     return string
-
 
 def fish_modifier_in_privmsg_cb(data, modifier, server_name, string):
     global fish_keys, fish_cyphers
@@ -634,9 +644,9 @@ def fish_modifier_in_privmsg_cb(data, modifier, server_name, string):
     clean = blowcrypt_unpack(match.group(5), b)
 
     if not match.group(4):
-        return "%s%s" % (match.group(1), clean)
+        return "%s%s" % (match.group(1), fish_msg_w_marker(clean))
 
-    return "%s%s%s\x01" % (match.group(1), match.group(4), clean)
+    return "%s%s%s\x01" % (match.group(1), match.group(4), fish_msg_w_marker(clean))
 
 
 def fish_modifier_in_topic_cb(data, modifier, server_name, string):
@@ -669,7 +679,7 @@ def fish_modifier_in_topic_cb(data, modifier, server_name, string):
 
     fish_announce_encrypted(buffer, target)
 
-    return "%s%s" % (match.group(1), clean)
+    return "%s%s" % (match.group(1), fish_msg_w_marker(clean))
 
 
 def fish_modifier_in_332_cb(data, modifier, server_name, string):
@@ -698,7 +708,7 @@ def fish_modifier_in_332_cb(data, modifier, server_name, string):
 
     fish_announce_encrypted(buffer, target)
 
-    return "%s%s" % (match.group(1), clean)
+    return "%s%s" % (match.group(1), fish_msg_w_marker(clean))
 
 
 def fish_modifier_out_privmsg_cb(data, modifier, server_name, string):
@@ -906,7 +916,14 @@ def fish_list_keys(buffer):
         (server, nick) = target.split("/")
         weechat.prnt(buffer, "\t%s(%s): %s" % (nick, server, key))
 
-
+def fish_msg_w_marker(msg):
+    marker = weechat.config_string(fish_config_option["mark_encrypted"])
+    if weechat.config_string(fish_config_option["mark_position"]) == "end":
+        return "%s%s" % (msg, marker)
+    elif weechat.config_string(fish_config_option["mark_position"]) == "begin":
+        return "%s%s" % (marker, msg)
+    else:
+        return msg
 #
 # MAIN
 #


### PR DESCRIPTION
Added mark_encrypted which works like mark_encrypted in fish-irssi. Depending
on mark_position either prefix or suffix message with string found in
mark_encrypted.
