### PR TITLE
fixes setting key when not specifying a target

### DIFF
--- a/fish.py
+++ b/fish.py
@@ -814,8 +814,10 @@ def fish_cmd_blowkey(data, buffer, args):
     pos = args.find(" ")
     if pos:
         pos = args.find(" ", pos + 1)
-        if pos:
+        if pos > 0:
             argv2eol = args[pos + 1:]
+        else:
+            argv2eol = args[args.find(" ") +1:]
 
     target = "%s/%s" % (server_name, target_user)
 


### PR DESCRIPTION
before when issuing `/blowkey set my_key` the key was set as `set my_key` for the current buffer
