### PR TITLE
decryption fix

### DIFF
--- a/fish.py
+++ b/fish.py
@@ -283,7 +283,7 @@ def blowcrypt_unpack(msg, cipher):
     except ValueError:
         raise MalformedError
 
-    return plain.strip('\x00')
+    return plain.strip('\x00').replace('\n','')
 
 
 #


### PR DESCRIPTION
removes newline character from decrypted string. this is the same behavior as mirc and fish10. without this lines sent with \n are sent as a command to the buffer and not printed as chat text
